### PR TITLE
Update travis.yml: Ubuntu-Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+dist: focal
 mono: none
 dotnet: 3.1.108
 script :


### PR DESCRIPTION
Als Standard ist Ubuntu 16.04 gesetzt. Hier endet die Standard-Support im April 2020. Bei der Neuentwicklung sollte eine aktuelles Betriebssystem genutzt werden.