### PR TITLE
Upgrade to dotnet 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ arch:
     - amd64
 solution: src/digitales-wachbuch.sln
 mono: none
-dotnet: 5.0
+dotnet: 6.0
 script :
     - dotnet restore src
     - dotnet build src

--- a/src/Wasserwacht.DigitalGuardBook.Base.Data/Wasserwacht.DigitalGuardBook.Base.Data.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Base.Data/Wasserwacht.DigitalGuardBook.Base.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Wasserwacht.DigitalGuardBook.Base.Logic/Wasserwacht.DigitalGuardBook.Base.Logic.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Base.Logic/Wasserwacht.DigitalGuardBook.Base.Logic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Wasserwacht.DigitalGuardBook.Base.Ui/Wasserwacht.DigitalGuardBook.Base.Ui.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Base.Ui/Wasserwacht.DigitalGuardBook.Base.Ui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
     <PackageReference Include="Radzen.Blazor" Version="3.13.8" />
   </ItemGroup>
 

--- a/src/Wasserwacht.DigitalGuardBook.Common.Data/Wasserwacht.DigitalGuardBook.Common.Data.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Common.Data/Wasserwacht.DigitalGuardBook.Common.Data.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Wasserwacht.DigitalGuardBook.Common.Logic/Wasserwacht.DigitalGuardBook.Common.Logic.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Common.Logic/Wasserwacht.DigitalGuardBook.Common.Logic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wasserwacht.DigitalGuardBook.Common.Ui/Wasserwacht.DigitalGuardBook.Common.Ui.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Common.Ui/Wasserwacht.DigitalGuardBook.Common.Ui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
     <PackageReference Include="Radzen.Blazor" Version="3.13.8" />
   </ItemGroup>
 

--- a/src/Wasserwacht.DigitalGuardBook.Common/Wasserwacht.DigitalGuardBook.Common.Data.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Common/Wasserwacht.DigitalGuardBook.Common.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Wasserwacht.DigitalGuardBook.Common/Wasserwacht.DigitalGuardBook.Common.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Common/Wasserwacht.DigitalGuardBook.Common.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Wasserwacht.DigitalGuardBook.Ui/Pages/Error.cshtml.cs
+++ b/src/Wasserwacht.DigitalGuardBook.Ui/Pages/Error.cshtml.cs
@@ -9,7 +9,7 @@ namespace Wasserwacht.DigitalGuardBook.Ui.Pages
     [IgnoreAntiforgeryToken]
     public class ErrorModel : PageModel
     {
-        public string RequestId { get; set; }
+        public string? RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 

--- a/src/Wasserwacht.DigitalGuardBook.Ui/Wasserwacht.DigitalGuardBook.Ui.csproj
+++ b/src/Wasserwacht.DigitalGuardBook.Ui/Wasserwacht.DigitalGuardBook.Ui.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnet-Wasserwacht.DigitalGuardBook.Ui-0980FBB2-771F-4B35-B546-C115FEC12A70</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.12">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
     <PackageReference Include="Radzen.Blazor" Version="3.13.8" />
   </ItemGroup>
 


### PR DESCRIPTION
Von .NET 5 auf .NET 6 akutalisiert, da .NET6 ein LTS-Release mit Support bis November 8, 2024 ist.